### PR TITLE
Change Credentials to Vault/IVault in docstrings

### DIFF
--- a/src/Internal/Api/Chain.elm
+++ b/src/Internal/Api/Chain.elm
@@ -26,7 +26,7 @@ superior ASCII snake model.)
 
 Every task will add another value to an extensible record, which can be used
 by later tasks in the chain. Additionally, every subtask can leave a `VaultUpdate`
-type as a message to the Credentials to update certain information.
+type as a message to the Vault to update certain information.
 
 -}
 

--- a/src/Internal/Values/Vault.elm
+++ b/src/Internal/Values/Vault.elm
@@ -1,6 +1,6 @@
 module Internal.Values.Vault exposing (..)
 
-{-| The Credentials type is the keychain of the Matrix SDK.
+{-| The IVault (Internal Vault) type is the keychain of the Matrix SDK.
 It handles all communication with the homeserver.
 -}
 
@@ -51,7 +51,7 @@ getInvites (IVault data) =
     data.invites
 
 
-{-| Get a room from the Credentials type by the room's id.
+{-| Get a room from the IVault type by the room's id.
 -}
 getRoomById : String -> IVault -> Maybe IRoom
 getRoomById roomId (IVault cred) =
@@ -72,7 +72,7 @@ getSince (IVault { since }) =
     since
 
 
-{-| Create new empty Credentials.
+{-| Create new empty IVault.
 -}
 init : IVault
 init =
@@ -102,7 +102,7 @@ insertAccountData { content, eventType, roomId } (IVault data) =
             IVault { data | accountData = Dict.insert eventType content data.accountData }
 
 
-{-| Add a new room to the Credentials type. If a room with this id already exists, it is overwritten.
+{-| Add a new room to the IVault type. If a room with this id already exists, it is overwritten.
 
 This function can hence also be used as an update function for rooms.
 


### PR DESCRIPTION
References to `Credentials` leftover from
e62b6a09c4b4bd9c7af3b3b2fa11bce6b49ad00c

Relatedly, the Dependencies graph is not updated yet, but I'm not sure how that's generated.